### PR TITLE
Fix expansion of command on execution of java path

### DIFF
--- a/samiam/runsamiam.bash
+++ b/samiam/runsamiam.bash
@@ -31,7 +31,7 @@ vmargs="-Xms8m -Xmx512m -classpath ${SAMIAMHOME}samiam.jar:${SAMIAMHOME}inflib.j
 type "${javalauncher}" >/dev/null 2>&1 && {
   execcmd=`type "${javalauncher}" 2>&1 | sed -ne 's#^[^/]*\([^)]*\).*$#\1#;\#'"${javalauncher}"'#p'`
   {
-    ${execcmd} ${vmargs} -launchcommand "${execcmd} ${vmargs} $*" -launchscript "$0" $*
+    "${execcmd}" ${vmargs} -launchcommand "${execcmd} ${vmargs} $*" -launchscript "$0" $*
     echo $?   >"${STATUS}" 2>/dev/null
   } 2>&1 | tee "${ERRORS}"
   [   -e       "${STATUS}" ] && exitstatus=`cat "${STATUS}"` || exitstatus=0
@@ -39,7 +39,7 @@ type "${javalauncher}" >/dev/null 2>&1 && {
     msg='Java exited with an error code ['"${exitstatus}"'].'
     [ -e       "${ERRORS}" ] && grep -qF 'calljvmti' "${ERRORS}" >/dev/null 2>&1 && {
       touch    "${SUPPRESS}" >/dev/null 2>&1
-      ${execcmd} ${vmargssafe} -launchcommand "${execcmd} ${vmargs} $*" -launchscript "$0" $*
+      "${execcmd}" ${vmargssafe} -launchcommand "${execcmd} ${vmargs} $*" -launchscript "$0" $*
       msg=
     }
     [ "${msg}" ] && echo "${msg}" 1>&2


### PR DESCRIPTION
This fix should deal with the unintended expansion of whitespaces when executing samiam on Mac OS X that could possibly cause the following error:

```
/Library/Internet: No such file or directory
```

The fix is simple: do not expand and instead interpret `execcmd` as a string by double quoting the command execution.